### PR TITLE
Added missing getAlpha()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,6 +119,12 @@ export class TinyColor {
     return 0.2126 * R + 0.7152 * G + 0.0722 * B;
   }
   /**
+   * Returns the alpha value of a color, from 0-1.
+   */
+  getAlpha(): number {
+    return this.a;
+  }
+  /**
    * Sets the alpha value on the current color.
    *
    * @param alpha - The new alpha value. The accepted range is 0-1.

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -454,6 +454,17 @@ describe('TinyColor', () => {
     redHex.setAlpha(0.38);
     expect(redHex.toString()).toBe('rgba(255, 0, 0, 0.38)');
   });
+  it('should get alpha', () => {
+    const hexSetter = new TinyColor('rgba(255, 0, 0, 1)');
+    // Alpha should start as 1
+    expect(hexSetter.getAlpha()).toBe(1);
+    const returnedFromSetAlpha = hexSetter.setAlpha(0.9);
+    // setAlpha should change alpha value
+    expect(returnedFromSetAlpha.getAlpha()).toBe(0.9);
+    hexSetter.setAlpha(0.5);
+    // setAlpha should change alpha value
+    expect(hexSetter.getAlpha()).toBe(0.5);
+  });
   it('should set alpha', () => {
     const hexSetter = new TinyColor('rgba(255, 0, 0, 1)');
     // Alpha should start as 1


### PR DESCRIPTION
Closes #89 

Either should the `getAlpha()` function be added, or it sould be removed from [the documentation](https://github.com/TypeCtrl/tinycolor#getalpha).