### PR TITLE
docs: Add documentation for mix()

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,17 @@ new TinyColor('#f00').spin(0).toString(); // "#ff0000"
 new TinyColor('#f00').spin(360).toString(); // "#ff0000"
 ```
 
+### mix
+
+`mix: function(amount = 50) => TinyColor`. Mix the current color a given amount with another color, from 0 to 100. 0 means no mixing (return current color).
+
+```ts
+let color1 = new TinyColor('#f0f');
+let color2 = new TinyColor('#0f0');
+
+color1.mix(color2).toHexString(); // #808080
+```
+
 ### Color Combinations
 
 Combination functions return an array of TinyColor objects unless otherwise noted.

--- a/src/index.ts
+++ b/src/index.ts
@@ -457,6 +457,10 @@ export class TinyColor {
     return new TinyColor(hsl);
   }
 
+  /**
+   * Mix the current color a given amount with another color, from 0 to 100.
+   * 0 means no mixing (return current color).
+   */
   mix(color: ColorInput, amount = 50) {
     const rgb1 = this.toRgb();
     const rgb2 = new TinyColor(color).toRgb();


### PR DESCRIPTION
Documentation was lacking for the `mix()` class method.