### PR TITLE
feat: mostReadable() accept default color format (not only string)

### DIFF
--- a/src/readability.ts
+++ b/src/readability.ts
@@ -78,7 +78,7 @@ export interface WCAG2FallbackParms extends WCAG2Parms {
  */
 export function mostReadable(
   baseColor: ColorInput,
-  colorList: string[],
+  colorList: ColorInput[],
   args: WCAG2FallbackParms = { includeFallbackColors: false, level: 'AA', size: 'small' },
 ): TinyColor | null {
   let bestColor: TinyColor | null = null;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -692,6 +692,7 @@ describe('TinyColor', () => {
   it('mostReadable', () => {
     expect(mostReadable('#000', ['#111', '#222'])!.toHexString()).toBe('#222222');
     expect(mostReadable('#f00', ['#d00', '#0d0'])!.toHexString()).toBe('#00dd00');
+    expect(mostReadable(new TinyColor('#f00'), [new TinyColor('#d00'), new TinyColor('#0d0')])!.toHexString()).toBe('#00dd00');
     expect(mostReadable('#fff', ['#fff', '#fff'])!.toHexString()).toBe('#ffffff');
     // includeFallbackColors
     expect(


### PR DESCRIPTION
There is no reason why `mostReadable()` not should accept `ColorInput` format, all places the input values is used, it is either converted to a `TinyColor`-object or passed to functions which accept `ColorInput`:
https://github.com/TypeCtrl/tinycolor/blob/3fb24fbc4e649d6ec25bf12041659a64daefd062/src/readability.ts#L88-L94
Both `readability()` and `new TinyColor()` expects `ColorInput`